### PR TITLE
NaN is not a number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# prove-params
+# provejs-params
 
 Prove function parameters using a simple schema.
 
 ## Install
 
 ```bash
-npm install prove-params --save
+npm install provejs-params --save
 ```
 
 ## Usage
 
 ```js
-var Prove = require('prove-params');
+var Prove = require('provejs-params');
 
 function myFunction(myArray, myNumber) {
 	Prove('AN', arguments);

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ function isString(arg) {
 }
 
 function isNumber(arg) {
-	return typeof arg === 'number';
+	var isNum = (typeof arg === 'number');
+	var isNan = isNaN(arg);
+	return isNum && !isNan;
 }
 
 function isFunction(arg) {


### PR DESCRIPTION
`NaN` does not pass the `isNumber()` check.
Fixed the package name in the README.md.